### PR TITLE
compatibility patch for python 3.4

### DIFF
--- a/pdfbox/__init__.py
+++ b/pdfbox/__init__.py
@@ -102,9 +102,10 @@ class PDFBox(object):
             except:
                 raise RuntimeError('error retrieving %s' % pdfbox_url)
             else:
-                cache_dir.mkdir(exist_ok=True, parents=True)
+                if not os.path.exists(cache_dir.as_posix()):
+                    cache_dir.mkdir(parents=True)
                 pdfbox_path = cache_dir.joinpath(pathlib.Path(pdfbox_url).name)
-                with open(pdfbox_path, 'wb') as f:
+                with open(pdfbox_path.as_posix(), 'wb') as f:
                     f.write(data)
 
             r = urllib.request.urlopen(sha512_url)


### PR DESCRIPTION
fixed the following issues
- `mkdir's` exist_ok parameter was introduced in python 3.5 so it won't work
    ```
    TypeError                                 Traceback (most recent call last)
    <ipython-input-51-e68d872ac2ee> in <module>()
    ----> 1 pdfreader = PDFBox()

    <ipython-input-50-102fb593b824> in __init__(self)
        113 
        114     def __init__(self):
    --> 115         self.pdfbox_path = self._get_pdfbox_path()
        116         self.java_path = shutil.which('java')
        117         if not self.java_path:

    <ipython-input-50-102fb593b824> in _get_pdfbox_path(self)
        95                 raise RuntimeError('error retrieving %s' % pdfbox_url)
        96             else:
    ---> 97                 cache_dir.mkdir(exist_ok=True, parents=True)
        98                 pdfbox_path = cache_dir.joinpath(pathlib.Path(pdfbox_url).name)
        99                 with open(pdfbox_path, 'wb') as f:

    TypeError: mkdir() got an unexpected keyword argument 'exist_ok'
    ```
- creating a file with Posix path on returns TypeError: invalid file:

    ```
    TypeError                                 Traceback (most recent call last)
    <ipython-input-53-e68d872ac2ee> in <module>()
    ----> 1 pdfreader = PDFBox()

    <ipython-input-52-f0e3aef44255> in __init__(self)
        114 
        115     def __init__(self):
    --> 116         self.pdfbox_path = self._get_pdfbox_path()
        117         self.java_path = shutil.which('java')
        118         if not self.java_path:

    <ipython-input-52-f0e3aef44255> in _get_pdfbox_path(self)
        98                     cache_dir.mkdir(parents=True)
        99                 pdfbox_path = cache_dir.joinpath(pathlib.Path(pdfbox_url).name)
    --> 100                 with open(pdfbox_path, 'wb') as f:
        101                     f.write(data)
        102 

    TypeError: invalid file: PosixPath('/home/ubuntu/.cache/python-pdfbox/pdfbox-app-2.0.14.jar')
    ```

Tested on python 3.4 in ubuntu 14.04